### PR TITLE
認証コードとアクセストークンの取得まではREADMEの説明に追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freee-api (0.0.5)
+    freee-api (0.0.6)
       faraday (~> 0.12.2)
       faraday_middleware (~> 0.12.2)
       oauth2 (~> 1.4.0)

--- a/lib/freee/api/version.rb
+++ b/lib/freee/api/version.rb
@@ -2,6 +2,6 @@
 
 module Freee
   module Api
-    VERSION = '0.0.5'
+    VERSION = '0.0.6'
   end
 end


### PR DESCRIPTION
トークン取得した後の各リクエストの操作はドキュメント読んでもらうようにする