### PR TITLE
README.mdのgem名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ freeeとの通信プロトコルはOAuth2を利用しています。
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'freee/api'
+gem 'freee-api'
 ```
 
 And then execute:


### PR DESCRIPTION
現状では `bundle install` を実行したときにエラーが発生するため、Gemfileに指定するgem名を修正